### PR TITLE
change doc script to improve travis build times

### DIFF
--- a/scripts/travis-doc-upload.sh
+++ b/scripts/travis-doc-upload.sh
@@ -5,10 +5,6 @@
 
 set -e
 
-cargo doc
-
-. ./scripts/doc.cfg
-
 [ "$TRAVIS_BRANCH" = master ]
 
 [ "$TRAVIS_OS_NAME" = linux ]
@@ -16,6 +12,10 @@ cargo doc
 [ "$TRAVIS_RUST_VERSION" = stable ]
 
 [ "$TRAVIS_PULL_REQUEST" = false ]
+
+cargo doc
+
+. ./scripts/doc.cfg
 
 eval key=\$encrypted_${SSH_KEY_TRAVIS_ID}_key
 eval iv=\$encrypted_${SSH_KEY_TRAVIS_ID}_iv


### PR DESCRIPTION
- move the cargo doc command below the os/version gates
