### PR TITLE
use std::time::Instant

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heatmap"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["Brian Martin <brayniac@gmail.com>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,4 @@ description = "heatmap storage, set of histograms"
 keywords = [ "heatmap", "histogram", "percentile", "statistics", "stats" ]
 
 [dependencies]
-time = "0.1.35"
 histogram = "0.6.1"


### PR DESCRIPTION
- save format is changed to use debug format of Instant
- save does not require mutable borrow
- merge does not require mutable borrow for other
- NOTE: load() from file is currently disabled
