### PR TITLE
cleanup: fix license text and add badges

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "heatmap"
 version = "0.6.5-pre"
 authors = ["Brian Martin <brayniac@gmail.com>"]
-license = "MIT OR Apache-2.0"
+license = "MIT/Apache-2.0"
 readme = "README.md"
 
 homepage = "https://github.com/brayniac/heatmap"

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright 2015 The heatmap Developers
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,18 @@
 # heatmap - a collection of histograms
 
-[placeholder]
+heatmap is a stats library for rust which provides time-sliced histogram
+storage capable of recording the distribution of values over time. It
+maintains precision guarentees throughout the range of stored values.
 
-[![Build Status](https://travis-ci.org/brayniac/heatmap.svg?branch=master)](https://travis-ci.org/brayniac/heatmap)
-[![crates.io](http://meritbadge.herokuapp.com/heatmap)](https://crates.io/crates/heatmap)
-[![License](http://img.shields.io/:license-mit-blue.svg)](http://doge.mit-license.org)
+[![travis-badge][]][travis] [![downloads-badge][] ![release-badge][]][crate] [![license-badge][]](#license)
+
+[travis-badge]: https://img.shields.io/travis/brayniac/heatmap/master.svg
+[downloads-badge]: https://img.shields.io/crates/d/heatmap.svg
+[release-badge]: https://img.shields.io/crates/v/heatmap.svg
+[license-badge]: https://img.shields.io/crates/l/heatmap.svg
+[travis]: https://travis-ci.org/brayniac/heatmap
+[crate]: https://crates.io/crates/heatmap
+[Cargo]: https://github.com/rust-lang/cargo
 
 ## Usage
 


### PR DESCRIPTION
- Cargo.toml use '/' instead of OR for license
- LICENSE-APACHE fill in the info
- badges